### PR TITLE
LIBSEARCH-71. Added second searcher limited to articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,45 @@ Run bundle install:
 bundle install
 ```
 
-Include in your Search Results page
+This gem provides two separate WorldCat Discovery searchers:
+
+* world_cat_discovery_api_searcher: A searcher that queries WorldCat Discovery
+  for all item types
+* world_cat_discovery_api_article_searcher: A searcher that limits the
+  WorldCat Discovery query to articles and book chapters
+
+The world_cat_discovery_api_article_searcher has special handling to return a
+direct link to the article (instead of to the WorldCat catalog entry), where
+possible.
+
+## Searcher Configuration
+
+### world_cat_discovery_api_searcher
+
+In your search application:
+
+1) Add the "world_cat_discovery_api" searcher to config/quick_search_config.yml
+
+2) Copy the config/world_cat_discovery_api_config.yml file into the
+   config/searchers/ directory and fill out the
+   values are appropriate.
+
+3) Include in your Search Results page
 
 ```
 <%= render_module(@world_cat_discovery_api, 'world_cat_discovery_api') %>
+```
+
+### world_cat_discovery_api_article
+
+1) Add the "world_cat_discovery_api_article" searcher to config/quick_search_config.yml
+
+2) Copy the config/world_cat_discovery_api_article_config.yml file into the
+   config/searchers/ directory and fill out the
+   values are appropriate.
+
+3) Include in your Search Results page
+
+```
+<%= render_module(@world_cat_discovery_api_article, 'world_cat_discovery_api_article') %>
 ```

--- a/app/searchers/quick_search/world_cat_discovery_api_article_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_article_searcher.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module QuickSearch
+  # QuickSearch seacher for WorldCat, restricted to articles
+  class WorldCatDiscoveryApiArticleSearcher < WorldCatDiscoveryApiSearcher
+    def query_params
+      {
+        q: http_request_queries['not_escaped'],
+        itemType: 'artchap',
+        startIndex: @offset,
+        itemsPerPage: items_per_page,
+        sortBy: 'library_plus_relevance'
+      }
+    end
+
+    def loaded_link
+      QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_ARTICLE_CONFIG['loaded_link'] +
+        http_request_queries['uri_escaped']
+    end
+
+    # Returns the link to use for the given item. If the item has a DOI
+    # a direct link to the item is returned, otherwise a link to the
+    # item in the OCLC catalog is returned.
+    def item_link(bib)
+      doi_link = bib.same_as&.to_s
+
+      if doi_link
+        doi_base_url = QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_ARTICLE_CONFIG['doi_link']
+        return doi_base_url + doi_link
+      end
+
+      QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_ARTICLE_CONFIG['url_link'] +
+        bib.oclc_number.to_s
+    end
+
+    # Returns the DOI link for the given item, or nil if no DOI is present
+    def doi_link(bib)
+      bib.same_as&.to_s
+    end
+  end
+end

--- a/config/initializers/world_cat_discovery_api_config.rb
+++ b/config/initializers/world_cat_discovery_api_config.rb
@@ -1,5 +1,14 @@
 # Try to load a local version of the config file if it exists - expected to be in quicksearch_root/config/searchers/<my_searcher_name>_config.yml
- 
+
+# Returns the value for the given key, first checking the WorldCat Discovery API
+# config file, and then falling back to the WorldCat Discovery API Article
+# configuration, if not found.
+def get_common_configuration(key)
+  QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG[key] ||
+  QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_ARTICLE_CONFIG[key]
+end
+
+# WorldCat Discovery API searcher configuration
 if File.exists?(File.join(Rails.root, '/config/searchers/world_cat_discovery_api_config.yml'))
   config_file = File.join Rails.root, '/config/searchers/world_cat_discovery_api_config.yml'
 else
@@ -8,11 +17,21 @@ else
 end
 QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG = YAML.load(ERB.new(File.read(config_file)).result)[Rails.env]
 
+# WorldCat Discovery API Article searcher configuration
+if File.exists?(File.join(Rails.root, '/config/searchers/world_cat_discovery_api_article_config.yml'))
+  config_file = File.join Rails.root, '/config/searchers/world_cat_discovery_api_article_config.yml'
+else
+  # otherwise load the default config file
+  config_file = File.expand_path('../../world_cat_discovery_api_article_config.yml', __FILE__)
+end
+QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_ARTICLE_CONFIG = YAML.load(ERB.new(File.read(config_file)).result)[Rails.env]
+
+
 # Get the configuration values
-key = QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG['wskey']
-secret = QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG['secret']
-authenticating_institution_id = QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG['authenticatingInstitutionId']
-context_institution_id = QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG['contextInstitutionId']
+key = get_common_configuration('wskey')
+secret = get_common_configuration('secret')
+authenticating_institution_id = get_common_configuration('authenticatingInstitutionId')
+context_institution_id = get_common_configuration('contextInstitutionId')
 
 # Create WSKey object
 wskey = OCLC::Auth::WSKey.new(key, secret, :services => ['WorldCatDiscoveryAPI'])

--- a/config/world_cat_discovery_api_article_config.yml
+++ b/config/world_cat_discovery_api_article_config.yml
@@ -12,20 +12,21 @@
 # <LOADED_LINK>: The base URL to send the query to
 # <URL_LINK>: The base URL for result links
 # <NO_RESULTS_LINK>: The URL to use when no results are found
-
+# <DOI_LINK>: The base URL to use for retrieving articles with DOIs
 defaults: &defaults
-  # The following propreties are common to both searchers. If the
-  # world_cat_discovery_api searcher is not being used, copy these
-  # properties into the world_cat_discovery_api_article_config.yml file
-  wskey: "<YOUR_WSKEY>"
-  secret: "<YOUR_SECRET>"
-  authenticatingInstitutionId: "<AUTENTICATING_INSTITUTION_ID>"
-  contextInstitutionId: "<CONTEXT_INSTITUTION_ID>"
 
-  # world_cat_discovery_api-specific properties
-  loaded_link: "<LOADED_LINK>"
-  url_link: "<URL_LINK>"
-  no_results_link: "<NO_RESULTS_LINK>"
+  # The following properties should only be defined when the
+  # world_cat_discovery_api_seacher is not being used.
+  # wskey: <%= ENV['WORLD_CAT_DISCOVERY_API_WSKEY'] %>
+  # secret: <%= ENV['WORLD_CAT_DISCOVERY_API_SECRET'] %>
+  # authenticatingInstitutionId: <%= ENV['WORLD_CAT_DISCOVERY_API_INSTITUTION_ID'] %>
+  # contextInstitutionId: <%= ENV['WORLD_CAT_DISCOVERY_API_INSTITUTION_ID'] %>
+
+  # world_cat_discovery_api_article-specific properties
+  loaded_link: <LOADED_LINK>
+  url_link: <URL_LINK>
+  no_results_link: <NO_RESULTS_LINK>
+  doi_link: <DOI_URL>
 
 development:
   <<: *defaults


### PR DESCRIPTION
Added "world_cat_discovery_api_article" searcher that performs a
WorldCat search that is limited to articles and book chapters
(uses an "itemType" parameter of "artchap").

https://issues.umd.edu/browse/LIBSEARCH-71