### PR TITLE
LIBSEARCH-67. Set sort order for world_cat_discovery_api_searcher

### DIFF
--- a/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
@@ -29,7 +29,8 @@ module QuickSearch
       {
         q: http_request_queries['not_escaped'],
         startIndex: @offset,
-        itemsPerPage: items_per_page
+        itemsPerPage: items_per_page,
+        sortBy: 'library_plus_relevance'
       }
     end
 


### PR DESCRIPTION
Set the "sortBy" field for the "world_cat_discovery_api_searcher" to
"library_plus_relevance".

The world_cat_discovery_api_article_searcher already is set to use the
"library_plus_relevance" in its "sortBy" field, so no change was needed
to that searcher.

Doing the simplest possible thing for now, as it seems unlikely that
the "sortBy" field will change too often. If this turns out to be
incorrect, we should consider making it into a environment-settable
configuration parameter.

https://issues.umd.edu/browse/LIBSEARCH-67