### PR TITLE
LIBSEARCH-72. Changed user search query processing to be more permissive

### DIFF
--- a/app/searchers/quick_search/world_cat_discovery_api_article_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_article_searcher.rb
@@ -5,7 +5,7 @@ module QuickSearch
   class WorldCatDiscoveryApiArticleSearcher < WorldCatDiscoveryApiSearcher
     def query_params
       {
-        q: http_request_queries['not_escaped'],
+        q: sanitized_user_search_query,
         itemType: 'artchap',
         startIndex: @offset,
         itemsPerPage: items_per_page,
@@ -15,7 +15,7 @@ module QuickSearch
 
     def loaded_link
       QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_ARTICLE_CONFIG['loaded_link'] +
-        http_request_queries['uri_escaped']
+        sanitized_user_search_query
     end
 
     # Returns the link to use for the given item. If the item has a DOI

--- a/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
@@ -27,7 +27,7 @@ module QuickSearch
 
     def query_params
       {
-        q: http_request_queries['not_escaped'],
+        q: sanitized_user_search_query,
         startIndex: @offset,
         itemsPerPage: items_per_page,
         sortBy: 'library_plus_relevance'
@@ -36,12 +36,20 @@ module QuickSearch
 
     def loaded_link
       QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG['loaded_link'] +
-        http_request_queries['uri_escaped']
+        sanitized_user_search_query
     end
 
     def item_link(bib)
       QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG['url_link'] +
         bib.oclc_number.to_s
+    end
+
+    # Returns the sanitized search query entered by the user, skipping
+    # the default QuickSearch query filtering
+    def sanitized_user_search_query
+      # Need to use "to_str" as otherwise Japanese text isn't returned
+      # properly
+      sanitize(@q).to_str
     end
 
     def items_per_page


### PR DESCRIPTION
The default QuickSearch user search query processing is very
restrictive, and prevents some common searches, such as those with
dashes. There were also difficulties with using search terms in foreign
languages such as Japanese.

Added "sanitized_user_search_query" method to return the user search
query that has only been passed through the "sanitize" method, which
results in a broader range of queries than that allows the default
QuickSearch user search query processing.

It is possible that even the "sanitize" method is not needed, but is
used here for whatever marginal benefit it might provide.

https://issues.umd.edu/browse/LIBSEARCH-72