### PR TITLE
LIBSEARCH-137. Added "item_format" field to results

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,15 @@ In your search application:
 ```
 <%= render_module(@world_cat_discovery_api_article, 'world_cat_discovery_api_article') %>
 ```
+
+## Additional Result Information
+
+The searchers return the following additional information about each item:
+
+* "item_format"
+  * The "world_cat_discovery_api" searcher will return  one of the following:
+    * "audio_book"
+    * "book"
+    * "e_book"
+    * "other" - Default if the type cannot be determined
+  * The "world_cat_discovery_api_article" searcher always returns "article"

--- a/app/searchers/quick_search/item_formats.rb
+++ b/app/searchers/quick_search/item_formats.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module QuickSearch
+  # Helper class for returning the item format from WorldCat Discovery API
+  # Bibliographic records
+  class ItemFormats
+    # Map of Bibligraphic book_formats to item format
+    @item_formats = {
+      'http://schema.org/Hardcover' => 'book',
+      'http://bibliograph.net/LargePrintBook' => 'book',
+      'http://schema.org/Paperback' => 'book',
+      'http://bibliograph.net/PrintBook' => 'book',
+      'http://bibliograph.net/AudioBook' => 'audio_book',
+      'http://schema.org/EBook' => 'e_book'
+    }
+
+    # Returns string representing the item format for the given
+    # Bibliographic record
+    def self.item_format(bib)
+      book_format = bib.book_format.to_s
+
+      @item_formats[book_format] || 'other'
+    end
+  end
+end

--- a/app/searchers/quick_search/world_cat_discovery_api_article_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_article_searcher.rb
@@ -37,5 +37,11 @@ module QuickSearch
     def doi_link(bib)
       bib.same_as&.to_s
     end
+
+    # Overrides the "item_format" method from the superclass to always
+    # return 'article'
+    def item_format(_bib)
+      'article'
+    end
   end
 end

--- a/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
@@ -10,15 +10,23 @@ module QuickSearch
     def results # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       return results_list[0..@per_page - 1] if results_list
       @results_list = []
+
       @response.bibs.each do |bib|
         result = OpenStruct.new
         result.title = bib.name
         result.link = item_link(bib)
         result.author = bib.author&.name
         result.date = bib.date_published
+        result.item_format = item_format(bib)
         @results_list << result
       end
       @results_list[0..@per_page - 1]
+    end
+
+    # Returns the item format for the given bib. Using a method so
+    # it can be overridden by subclasses.
+    def item_format(bib)
+      ItemFormats.item_format(bib) || 'other'
     end
 
     def total


### PR DESCRIPTION
Modified "results" to return an "item_format" field for each item.

https://issues.umd.edu/browse/LIBSEARCH-137