### PR TITLE
LIBSEARCH-156. Modified searcher to use percent-encoded query term

### DIFF
--- a/app/searchers/quick_search/world_cat_discovery_api_article_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_article_searcher.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module QuickSearch
-  # QuickSearch seacher for WorldCat, restricted to articles
+  # QuickSearch searcher for WorldCat, restricted to articles
   class WorldCatDiscoveryApiArticleSearcher < WorldCatDiscoveryApiSearcher
     def query_params
       {
-        q: sanitized_user_search_query,
+        q: http_request_queries['not_escaped'],
         itemType: 'artchap',
         startIndex: @offset,
         itemsPerPage: items_per_page,
@@ -15,7 +15,7 @@ module QuickSearch
 
     def loaded_link
       QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_ARTICLE_CONFIG['loaded_link'] +
-        sanitized_user_search_query
+        percent_encoded_raw_user_search_query
     end
 
     # Returns the link to use for the given item. If the item has a DOI

--- a/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module QuickSearch
-  # QuickSearch seacher for WorldCat
+  # QuickSearch searcher for WorldCat
   class WorldCatDiscoveryApiSearcher < QuickSearch::Searcher
     def search
       @response = WorldCat::Discovery::Bib.search(query_params)
@@ -35,7 +35,7 @@ module QuickSearch
 
     def query_params
       {
-        q: sanitized_user_search_query,
+        q: http_request_queries['not_escaped'],
         startIndex: @offset,
         itemsPerPage: items_per_page,
         sortBy: 'library_plus_relevance'
@@ -44,7 +44,7 @@ module QuickSearch
 
     def loaded_link
       QuickSearch::Engine::WORLD_CAT_DISCOVERY_API_CONFIG['loaded_link'] +
-        sanitized_user_search_query
+        percent_encoded_raw_user_search_query
     end
 
     def item_link(bib)
@@ -52,12 +52,10 @@ module QuickSearch
         bib.oclc_number.to_s
     end
 
-    # Returns the sanitized search query entered by the user, skipping
+    # Returns the percent-encoded search query entered by the user, skipping
     # the default QuickSearch query filtering
-    def sanitized_user_search_query
-      # Need to use "to_str" as otherwise Japanese text isn't returned
-      # properly
-      sanitize(@q).to_str
+    def percent_encoded_raw_user_search_query
+      CGI.escape(@q)
     end
 
     def items_per_page


### PR DESCRIPTION
Added "percent_encoded_raw_user_search_query" method which returns a
percent-encoded representation of the raw query term entered by the
user.

Modified the searcher to send raw percent-encoded query in the
"loaded_link" method. Kept usage of the
http_request_queries['uri_escaped'] parameter for searching, it seems
to give better results (i.e., results more consistent with the WorldCat
native interface).

https://issues.umd.edu/browse/LIBSEARCH-156