### PR TITLE
LIBSEARCH-158. Updated item formats for WorldCat

### DIFF
--- a/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
+++ b/app/searchers/quick_search/world_cat_discovery_api_searcher.rb
@@ -26,7 +26,7 @@ module QuickSearch
     # Returns the item format for the given bib. Using a method so
     # it can be overridden by subclasses.
     def item_format(bib)
-      ItemFormats.item_format(bib) || 'other'
+      ItemFormats.item_format(bib)
     end
 
     def total
@@ -72,20 +72,84 @@ module QuickSearch
   class ItemFormats
     # Map of Bibligraphic book_formats to item format
     @item_formats = {
+      'http://purl.org/library/ArchiveMaterial' => 'archival_material',
+      'http://schema.org/Article' => 'article',
+      'http://bibliograph.net/AudioBook' => 'audio_book',
+      'http://schema.org/Book' => 'book',
       'http://schema.org/Hardcover' => 'book',
       'http://bibliograph.net/LargePrintBook' => 'book',
       'http://schema.org/Paperback' => 'book',
       'http://bibliograph.net/PrintBook' => 'book',
-      'http://bibliograph.net/AudioBook' => 'audio_book',
-      'http://schema.org/EBook' => 'e_book'
+      'http://bibliograph.net/CD' => 'cd',
+      'http://www.productontology.org/id/Compact_Disc' => 'cd',
+      'http://bibliograph.net/ComputerFile' => 'computer_file',
+      'http://bibliograph.net/DVD' => 'dvd',
+      'http://www.productontology.org/doc/DVD' => 'dvd',
+      'http://schema.org/EBook' => 'e_book',
+      'http://bibliograph.net/Image' => 'image',
+      'http://www.productontology.org/doc/Image' => 'image',
+      'http://purl.org/library/VisualMaterial' => 'image',
+      'http://schema.org/Periodical' => 'journal',
+      'http://purl.org/library/Serial' => 'journal',
+      'http://bibliograph.net/LPRecord' => 'lp',
+      'http://www.productontology.org/id/LP_record' => 'lp',
+      'http://bibliograph.net/Atlas' => 'map',
+      'http://schema.org/Map' => 'map',
+      'http://bibliograph.net/Newspaper' => 'newspaper',
+      'http://bibliograph.net/MusicScore' => 'score',
+      'http://purl.org/ontology/mo/Score' => 'score',
+      'http://www.productontology.org/id/Sheet_music' => 'score',
+      'http://bibliograph.net/Thesis' => 'thesis',
+      'http://www.productontology.org/id/Thesis' => 'thesis'
+    }
+
+    # Map of Bibligraphic genres to item format
+    @genres = {
+      'Streaming audio' => 'e_music',
+      'Downloadable audio file' => 'e_music',
+      'Internet videos' => 'e_video',
+      'Streaming videos' => 'e_video'
     }
 
     # Returns string representing the item format for the given
     # Bibliographic record
-    def self.item_format(bib)
-      book_format = bib.book_format.to_s
+    def self.item_format(bib) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/LineLength
+      best_type = WorldCat::Discovery::Bib.choose_best_type(bib)
+      type = bib.type
 
-      @item_formats[book_format] || 'other'
+      types = bib.types
+      if type.to_s == 'http://schema.org/Book'
+        # Remove Book type from types, if present, as
+        # the array may have a more specific type
+        types = bib.types - [type]
+      end
+
+      book_format = bib.book_format
+      genres = bib.genres
+
+      if best_type.is_a? WorldCat::Discovery::MusicAlbum
+        format = best_type.format
+
+        if format.present?
+          music_format = format.map { |f| @item_formats[f.to_s] }.compact.first
+          return music_format
+        end
+      end
+
+      type_item_format = @item_formats[type.to_s]
+      types_item_format = types.map { |t| @item_formats[t.to_s] }.compact.first
+      book_item_format = @item_formats[book_format.to_s]
+      genres_item_format = genres.map { |g| @genres[g] }.compact.first
+
+      # Order is important -- we are trying to return the most specific type
+      return book_item_format if book_item_format
+      return types_item_format if types_item_format
+      return type_item_format if type_item_format
+      return genres_item_format if genres_item_format
+
+      default_format = 'other'
+      # Return default
+      default_format
     end
   end
 end


### PR DESCRIPTION
Updated the "item_format" method to better recognize the item format
from the bib record.

Updated @item_formats map based on
"Discovery Committee/Item Format Mapping" document on Google Drive

Added "@genres" map to help distinguish a few item formats.

https://issues.umd.edu/browse/LIBSEARCH-158